### PR TITLE
Sandbox iframe tokens to make them more secure

### DIFF
--- a/components/token/TokenMedia.tsx
+++ b/components/token/TokenMedia.tsx
@@ -149,6 +149,7 @@ const Media: FC<{
         height="533"
         width="533"
         src={animation_url}
+        sandbox="allow-scripts"
       ></iframe>
     )
   }


### PR DESCRIPTION
Fixes #278, turns sandbox mode on for iframes. Preventing them from executing code on the main website and using the postMessage api if from a different domain, among other things.

https://www.w3schools.com/tags/att_iframe_sandbox.asp